### PR TITLE
fix: avoid full height on mobile

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -523,7 +523,7 @@ export default function Home() {
           <section
             className={`
               w-full p-4 flex flex-col
-              ${viewMode === 'split' ? 'md:h-auto border-b md:border-b-0 md:border-r border-gray-200' : 'h-full'}
+              ${viewMode === 'split' ? 'md:h-auto border-b md:border-b-0 md:border-r border-gray-200' : 'md:h-full'}
             `}
             style={
               viewMode === 'split' ? { width: '100%', flexBasis: `${ratio * 100}%` } : undefined
@@ -569,7 +569,7 @@ export default function Home() {
           <section
             className={`
               w-full p-4 flex flex-col
-              ${viewMode === 'split' ? '' : 'h-full'}
+              ${viewMode === 'split' ? '' : 'md:h-full'}
             `}
             style={
               viewMode === 'split'

--- a/components/MarkdownEditor.tsx
+++ b/components/MarkdownEditor.tsx
@@ -9,71 +9,75 @@ interface MarkdownEditorProps {
   scrollToPercentage?: number;
 }
 
-const MarkdownEditor = forwardRef<HTMLTextAreaElement, MarkdownEditorProps>(
-  function MarkdownEditor({ value, onChange, onScroll, scrollToPercentage }, ref) {
-    const internalRef = useRef<HTMLTextAreaElement>(null);
-    const isScrollingSelfRef = useRef(false);
+const MarkdownEditor = forwardRef<HTMLTextAreaElement, MarkdownEditorProps>(function MarkdownEditor(
+  { value, onChange, onScroll, scrollToPercentage },
+  ref
+) {
+  const internalRef = useRef<HTMLTextAreaElement>(null);
+  const isScrollingSelfRef = useRef(false);
 
-    // Use the forwarded ref or the internal ref
-    const textareaRef = (ref as React.RefObject<HTMLTextAreaElement>) || internalRef;
+  // Use the forwarded ref or the internal ref
+  const textareaRef = (ref as React.RefObject<HTMLTextAreaElement>) || internalRef;
 
-    const handleScroll = useCallback((e: Event) => {
+  const handleScroll = useCallback(
+    (e: Event) => {
       if (isScrollingSelfRef.current) return;
-      
+
       const target = e.target as HTMLTextAreaElement;
       const scrollTop = target.scrollTop;
       const scrollHeight = target.scrollHeight;
       const clientHeight = target.clientHeight;
-      
+
       if (scrollHeight <= clientHeight) return;
-      
+
       const scrollPercentage = scrollTop / (scrollHeight - clientHeight);
       onScroll?.(scrollPercentage);
-    }, [onScroll]);
+    },
+    [onScroll]
+  );
 
-    // Handle external scroll commands
-    useEffect(() => {
-      if (scrollToPercentage === undefined || !textareaRef.current) return;
-      
-      const textarea = textareaRef.current;
-      const scrollHeight = textarea.scrollHeight;
-      const clientHeight = textarea.clientHeight;
-      
-      if (scrollHeight <= clientHeight) return;
-      
-      isScrollingSelfRef.current = true;
-      textarea.scrollTop = scrollToPercentage * (scrollHeight - clientHeight);
-      
-      // Reset flag after a short delay
-      setTimeout(() => {
-        isScrollingSelfRef.current = false;
-      }, 100);
-    }, [scrollToPercentage, textareaRef]);
+  // Handle external scroll commands
+  useEffect(() => {
+    if (scrollToPercentage === undefined || !textareaRef.current) return;
 
-    // Add scroll event listener
-    useEffect(() => {
-      const textarea = textareaRef.current;
-      if (!textarea || !onScroll) return;
-      
-      textarea.addEventListener('scroll', handleScroll);
-      return () => textarea.removeEventListener('scroll', handleScroll);
-    }, [handleScroll, onScroll, textareaRef]);
+    const textarea = textareaRef.current;
+    const scrollHeight = textarea.scrollHeight;
+    const clientHeight = textarea.clientHeight;
 
-    return (
-      <textarea
-        ref={textareaRef}
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder="Start typing your markdown here..."
-        className="w-full h-full p-4 border border-gray-200 rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white text-black font-mono text-sm leading-relaxed overflow-auto"
-        spellCheck={false}
-        aria-label="Markdown editor textarea"
-        aria-describedby="editor-description"
-        role="textbox"
-        aria-multiline="true"
-      />
-    );
-  }
-);
+    if (scrollHeight <= clientHeight) return;
+
+    isScrollingSelfRef.current = true;
+    textarea.scrollTop = scrollToPercentage * (scrollHeight - clientHeight);
+
+    // Reset flag after a short delay
+    setTimeout(() => {
+      isScrollingSelfRef.current = false;
+    }, 100);
+  }, [scrollToPercentage, textareaRef]);
+
+  // Add scroll event listener
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea || !onScroll) return;
+
+    textarea.addEventListener('scroll', handleScroll);
+    return () => textarea.removeEventListener('scroll', handleScroll);
+  }, [handleScroll, onScroll, textareaRef]);
+
+  return (
+    <textarea
+      ref={textareaRef}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder="Start typing your markdown here..."
+      className="w-full md:h-full p-4 border border-gray-200 rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white text-black font-mono text-sm leading-relaxed overflow-auto"
+      spellCheck={false}
+      aria-label="Markdown editor textarea"
+      aria-describedby="editor-description"
+      role="textbox"
+      aria-multiline="true"
+    />
+  );
+});
 
 export default MarkdownEditor;

--- a/components/MarkdownPreview.tsx
+++ b/components/MarkdownPreview.tsx
@@ -75,7 +75,9 @@ function CodeBlock({ className, children, ...props }: React.ComponentProps<'code
         </button>
       </div>
       <pre ref={preRef}>
-        <code className={className} {...props}>{children}</code>
+        <code className={className} {...props}>
+          {children}
+        </code>
       </pre>
     </div>
   );
@@ -199,123 +201,129 @@ const components: Components = {
   },
 };
 
-const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
-  function MarkdownPreview({ content, theme = 'default', onScroll, scrollToPercentage }, ref) {
-    const [hlPlugin, setHlPlugin] = useState<any>(null);
-    const currentTheme = getTheme(theme);
-    const internalRef = useRef<HTMLDivElement>(null);
-    const isScrollingSelfRef = useRef(false);
+const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(function MarkdownPreview(
+  { content, theme = 'default', onScroll, scrollToPercentage },
+  ref
+) {
+  const [hlPlugin, setHlPlugin] = useState<any>(null);
+  const currentTheme = getTheme(theme);
+  const internalRef = useRef<HTMLDivElement>(null);
+  const isScrollingSelfRef = useRef(false);
 
-    // Use the forwarded ref or the internal ref
-    const previewRef = (ref as React.RefObject<HTMLDivElement>) || internalRef;
+  // Use the forwarded ref or the internal ref
+  const previewRef = (ref as React.RefObject<HTMLDivElement>) || internalRef;
 
-    const handleScroll = useCallback((e: Event) => {
+  const handleScroll = useCallback(
+    (e: Event) => {
       if (isScrollingSelfRef.current) return;
-      
+
       const target = e.target as HTMLDivElement;
       const scrollTop = target.scrollTop;
       const scrollHeight = target.scrollHeight;
       const clientHeight = target.clientHeight;
-      
+
       if (scrollHeight <= clientHeight) return;
-      
+
       const scrollPercentage = scrollTop / (scrollHeight - clientHeight);
       onScroll?.(scrollPercentage);
-    }, [onScroll]);
+    },
+    [onScroll]
+  );
 
-    // Handle external scroll commands
-    useEffect(() => {
-      if (scrollToPercentage === undefined || !previewRef.current) return;
-      
-      const preview = previewRef.current;
-      const scrollHeight = preview.scrollHeight;
-      const clientHeight = preview.clientHeight;
-      
-      if (scrollHeight <= clientHeight) return;
-      
-      isScrollingSelfRef.current = true;
-      preview.scrollTop = scrollToPercentage * (scrollHeight - clientHeight);
-      
-      // Reset flag after a short delay
-      setTimeout(() => {
-        isScrollingSelfRef.current = false;
-      }, 100);
-    }, [scrollToPercentage, previewRef]);
+  // Handle external scroll commands
+  useEffect(() => {
+    if (scrollToPercentage === undefined || !previewRef.current) return;
 
-    // Add scroll event listener
-    useEffect(() => {
-      const preview = previewRef.current;
-      if (!preview || !onScroll) return;
-      
-      preview.addEventListener('scroll', handleScroll);
-      return () => preview.removeEventListener('scroll', handleScroll);
-    }, [handleScroll, onScroll, previewRef]);
+    const preview = previewRef.current;
+    const scrollHeight = preview.scrollHeight;
+    const clientHeight = preview.clientHeight;
 
-    useEffect(() => {
-      let active = true;
-      import('rehype-highlight').then((m) => {
-        if (active) setHlPlugin(() => (m as any).default ?? (m as any));
-      });
-      return () => { active = false };
-    }, []);
+    if (scrollHeight <= clientHeight) return;
 
-    const rehypePlugins = useMemo(() => (hlPlugin ? [hlPlugin] : []), [hlPlugin]);
+    isScrollingSelfRef.current = true;
+    preview.scrollTop = scrollToPercentage * (scrollHeight - clientHeight);
 
-    // Inject custom theme styles and syntax highlighting
-    useEffect(() => {
-      const styleId = 'theme-custom-styles';
-      let styleElement = document.getElementById(styleId) as HTMLStyleElement;
-      
-      if (!styleElement) {
-        styleElement = document.createElement('style');
-        styleElement.id = styleId;
-        document.head.appendChild(styleElement);
-      }
-      
-      // Load appropriate syntax highlighting theme
-      let syntaxTheme = '';
-      if (theme === 'dark' || theme === 'terminal') {
-        // Use dark syntax highlighting
-        syntaxTheme = `
+    // Reset flag after a short delay
+    setTimeout(() => {
+      isScrollingSelfRef.current = false;
+    }, 100);
+  }, [scrollToPercentage, previewRef]);
+
+  // Add scroll event listener
+  useEffect(() => {
+    const preview = previewRef.current;
+    if (!preview || !onScroll) return;
+
+    preview.addEventListener('scroll', handleScroll);
+    return () => preview.removeEventListener('scroll', handleScroll);
+  }, [handleScroll, onScroll, previewRef]);
+
+  useEffect(() => {
+    let active = true;
+    import('rehype-highlight').then((m) => {
+      if (active) setHlPlugin(() => (m as any).default ?? (m as any));
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const rehypePlugins = useMemo(() => (hlPlugin ? [hlPlugin] : []), [hlPlugin]);
+
+  // Inject custom theme styles and syntax highlighting
+  useEffect(() => {
+    const styleId = 'theme-custom-styles';
+    let styleElement = document.getElementById(styleId) as HTMLStyleElement;
+
+    if (!styleElement) {
+      styleElement = document.createElement('style');
+      styleElement.id = styleId;
+      document.head.appendChild(styleElement);
+    }
+
+    // Load appropriate syntax highlighting theme
+    let syntaxTheme = '';
+    if (theme === 'dark' || theme === 'terminal') {
+      // Use dark syntax highlighting
+      syntaxTheme = `
           @import url('https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css');
         `;
-      } else {
-        // Use light syntax highlighting (default)
-        syntaxTheme = `
+    } else {
+      // Use light syntax highlighting (default)
+      syntaxTheme = `
           @import url('https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css');
         `;
-      }
-      
-      styleElement.textContent = syntaxTheme + (currentTheme.customStyles || '');
-      
-      return () => {
-        // Keep the style element for theme switching, just update content
-      };
-    }, [currentTheme, theme]);
+    }
 
-    return (
-      <div 
-        ref={previewRef}
-        className={`${currentTheme.classes.container} h-full overflow-auto`}
-        role="region"
-        aria-label="Markdown preview area"
-        aria-live="polite"
-        aria-describedby="preview-description"
-        data-theme={theme}
-      >
-        <div className={currentTheme.classes.prose}>
-          <ReactMarkdown
-            remarkPlugins={[remarkGfm]}
-            rehypePlugins={rehypePlugins}
-            skipHtml
-            components={components}
-          >
-            {content}
-          </ReactMarkdown>
-        </div>
+    styleElement.textContent = syntaxTheme + (currentTheme.customStyles || '');
+
+    return () => {
+      // Keep the style element for theme switching, just update content
+    };
+  }, [currentTheme, theme]);
+
+  return (
+    <div
+      ref={previewRef}
+      className={currentTheme.classes.container}
+      role="region"
+      aria-label="Markdown preview area"
+      aria-live="polite"
+      aria-describedby="preview-description"
+      data-theme={theme}
+    >
+      <div className={currentTheme.classes.prose}>
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
+          rehypePlugins={rehypePlugins}
+          skipHtml
+          components={components}
+        >
+          {content}
+        </ReactMarkdown>
       </div>
-    );
-  }
-);
+    </div>
+  );
+});
 
 export default MarkdownPreview;

--- a/lib/themes.ts
+++ b/lib/themes.ts
@@ -15,17 +15,17 @@ export const themes: Theme[] = [
     displayName: 'Default',
     description: 'Clean and minimal design',
     classes: {
-      container: 'h-full overflow-auto p-4 bg-white border border-gray-200 rounded-lg',
-      prose: 'prose prose-slate max-w-none'
-    }
+      container: 'md:h-full overflow-auto p-4 bg-white border border-gray-200 rounded-lg',
+      prose: 'prose prose-slate max-w-none',
+    },
   },
   {
     name: 'dark',
     displayName: 'Dark',
     description: 'Dark theme for low-light environments',
     classes: {
-      container: 'h-full overflow-auto p-4 bg-gray-900 border border-gray-700 rounded-lg',
-      prose: 'prose prose-invert max-w-none dark-theme'
+      container: 'md:h-full overflow-auto p-4 bg-gray-900 border border-gray-700 rounded-lg',
+      prose: 'prose prose-invert max-w-none dark-theme',
     },
     customStyles: `
       .dark-theme {
@@ -100,15 +100,15 @@ export const themes: Theme[] = [
       .dark-theme .mdv-code .copy-button .text-green-600 {
         color: #10b981 !important;
       }
-    `
+    `,
   },
   {
     name: 'github',
     displayName: 'GitHub',
     description: 'GitHub-like styling',
     classes: {
-      container: 'h-full overflow-auto p-6 bg-white border border-gray-300 rounded-lg',
-      prose: 'prose prose-slate max-w-none github-theme'
+      container: 'md:h-full overflow-auto p-6 bg-white border border-gray-300 rounded-lg',
+      prose: 'prose prose-slate max-w-none github-theme',
     },
     customStyles: `
       .github-theme h1 { 
@@ -155,15 +155,15 @@ export const themes: Theme[] = [
       .github-theme table td {
         border: 1px solid #d0d7de;
       }
-    `
+    `,
   },
   {
     name: 'notion',
     displayName: 'Notion',
     description: 'Notion-inspired design',
     classes: {
-      container: 'h-full overflow-auto p-6 bg-white border-0 rounded-lg',
-      prose: 'prose prose-slate max-w-none notion-theme'
+      container: 'md:h-full overflow-auto p-6 bg-white border-0 rounded-lg',
+      prose: 'prose prose-slate max-w-none notion-theme',
     },
     customStyles: `
       .notion-theme {
@@ -202,15 +202,15 @@ export const themes: Theme[] = [
         padding: 0.2em 0.4em;
         font-size: 85%;
       }
-    `
+    `,
   },
   {
     name: 'medium',
     displayName: 'Medium',
     description: 'Medium.com-style typography',
     classes: {
-      container: 'h-full overflow-auto p-8 bg-white border-0 rounded-lg',
-      prose: 'prose prose-slate max-w-none medium-theme'
+      container: 'md:h-full overflow-auto p-8 bg-white border-0 rounded-lg',
+      prose: 'prose prose-slate max-w-none medium-theme',
     },
     customStyles: `
       .medium-theme {
@@ -278,15 +278,16 @@ export const themes: Theme[] = [
         font-family: Menlo, Monaco, "Courier New", Courier, monospace;
         font-size: 16px;
       }
-    `
+    `,
   },
   {
     name: 'paper',
     displayName: 'Paper',
     description: 'Academic paper style',
     classes: {
-      container: 'h-full overflow-auto p-12 bg-white border border-gray-200 rounded-lg shadow-lg',
-      prose: 'prose prose-slate max-w-none paper-theme'
+      container:
+        'md:h-full overflow-auto p-12 bg-white border border-gray-200 rounded-lg shadow-lg',
+      prose: 'prose prose-slate max-w-none paper-theme',
     },
     customStyles: `
       .paper-theme {
@@ -353,15 +354,15 @@ export const themes: Theme[] = [
         background: #f0f0f0;
         font-weight: bold;
       }
-    `
+    `,
   },
   {
     name: 'minimal',
     displayName: 'Minimal',
     description: 'Ultra-clean minimal design',
     classes: {
-      container: 'h-full overflow-auto p-4 bg-gray-50 border-0 rounded-lg',
-      prose: 'prose prose-gray max-w-none minimal-theme'
+      container: 'md:h-full overflow-auto p-4 bg-gray-50 border-0 rounded-lg',
+      prose: 'prose prose-gray max-w-none minimal-theme',
     },
     customStyles: `
       .minimal-theme {
@@ -424,15 +425,15 @@ export const themes: Theme[] = [
         font-weight: 600;
         color: #555;
       }
-    `
+    `,
   },
   {
     name: 'terminal',
     displayName: 'Terminal',
     description: 'Retro terminal/console style',
     classes: {
-      container: 'h-full overflow-auto p-4 bg-black border border-green-500 rounded-lg',
-      prose: 'prose prose-invert max-w-none terminal-theme'
+      container: 'md:h-full overflow-auto p-4 bg-black border border-green-500 rounded-lg',
+      prose: 'prose prose-invert max-w-none terminal-theme',
     },
     customStyles: `
       .terminal-theme {
@@ -519,14 +520,14 @@ export const themes: Theme[] = [
       .terminal-theme .mdv-code .copy-button .text-green-600 {
         color: #00ff00 !important;
       }
-    `
-  }
+    `,
+  },
 ];
 
 export function getTheme(themeName: string): Theme {
-  return themes.find(theme => theme.name === themeName) || themes[0];
+  return themes.find((theme) => theme.name === themeName) || themes[0];
 }
 
 export function getThemeNames(): string[] {
-  return themes.map(theme => theme.name);
+  return themes.map((theme) => theme.name);
 }


### PR DESCRIPTION
## Summary
- avoid forcing full-height panels on mobile
- delegate preview sizing to themes without extra class
- mark theme container styles as md:h-full

## Testing
- `npm run lint`
- `npm run typecheck`
- `npx prettier components/MarkdownEditor.tsx components/MarkdownPreview.tsx lib/themes.ts app/page.tsx --check`


------
https://chatgpt.com/codex/tasks/task_e_68bc10e840ec83228afde48de5adb525