### PR TITLE
feat: refresh markdown workspace styling

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type React from "react";
 import Link from "next/link";
 import RichMarkdownEditor from "../components/RichMarkdownEditor";
@@ -10,7 +10,16 @@ import CompactThemeSelector from "../components/CompactThemeSelector";
 import ViewModeSelector from "../components/ViewModeSelector";
 import QuickActionsMenu from "../components/QuickActionsMenu";
 import { themes, getTheme } from "../lib/themes";
-import { Upload, FileText, FileCode, RotateCw, BookOpen, Edit3, Eye, Columns, Settings, MoreHorizontal, Github } from "lucide-react";
+import {
+  Upload,
+  FileText,
+  FileCode,
+  RotateCw,
+  BookOpen,
+  Github,
+  Sparkles,
+  ShieldCheck,
+} from "lucide-react";
 
 type ViewMode = 'split' | 'editor' | 'preview';
 
@@ -146,6 +155,21 @@ export default function Home() {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const previewRef = useRef<HTMLDivElement | null>(null);
   const editorRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const wordCount = useMemo(
+    () => markdown.split(/\s+/).filter((word) => word.length > 0).length,
+    [markdown],
+  );
+  const lineCount = useMemo(() => markdown.split('\n').length, [markdown]);
+  const fileSizeInKb = useMemo(() => new Blob([markdown]).size / 1024, [markdown]);
+  const formattedFileSize = useMemo(() => {
+    if (fileSizeInKb < 0.1) return '<0.1 KB';
+    if (fileSizeInKb < 10) return `${fileSizeInKb.toFixed(1)} KB`;
+    return `${Math.round(fileSizeInKb)} KB`;
+  }, [fileSizeInKb]);
+
+  const actionButtonClass =
+    "inline-flex items-center gap-1.5 rounded-lg border border-white/70 bg-white/70 px-2.5 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:bg-white focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-2 focus:ring-offset-white";
 
   // Load from localStorage
   useEffect(() => {
@@ -356,193 +380,225 @@ export default function Home() {
   }, [viewMode]);
 
   return (
-    <div className="h-screen flex flex-col">
-      {/* Header */}
-      <header className="bg-white border-b border-gray-200 shadow-sm">
-        <div className="max-w-full mx-auto px-3 sm:px-4 md:px-6">
-          {/* Main navigation bar */}
-          <div className="flex items-center justify-between h-14 md:h-16">
-            {/* Left section - Logo and title */}
-            <div className="flex items-center gap-2 md:gap-4">
-              <Link
-                href="/"
-                className="flex items-center gap-2 md:gap-3 group rounded-lg p-1.5 md:p-2 hover:bg-gray-50 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
-                aria-label="MD-View Home"
-                title="MD-View Home"
-              >
-                <img
-                  src="/md-view-icon.svg"
-                  alt="MD-View logo"
-                  className="h-7 w-7 md:h-8 md:w-8 rounded group-hover:scale-105 transition-transform"
-                />
-                <div className="hidden sm:block">
-                  <h1 className="text-lg md:text-xl font-bold text-gray-900">MD-View</h1>
-                  <p className="text-xs text-gray-500 leading-tight">Markdown Editor</p>
-                </div>
-              </Link>
-              
-              {/* View mode selector */}
-              <div className="hidden md:block">
-                <ViewModeSelector currentMode={viewMode} onModeChange={setViewMode} />
-              </div>
-
-              {/* Document stats */}
-              <div className="hidden xl:flex items-center gap-3 text-xs text-gray-500 bg-gray-50 px-3 py-1.5 rounded-lg">
-                <span>
-                  {markdown.split(/\s+/).filter(word => word.length > 0).length} words
-                </span>
-                <span>•</span>
-                <span>
-                  {markdown.split('\n').length} lines
-                </span>
-                <span>•</span>
-                <span>
-                  {Math.round(new Blob([markdown]).size / 1024)}KB
-                </span>
-              </div>
-            </div>
-
-            {/* Right section - Actions */}
-            <div className="flex items-center gap-2 md:gap-3">
-              {/* Mobile view mode selector */}
-              <div className="md:hidden">
-                <ViewModeSelector currentMode={viewMode} onModeChange={setViewMode} />
-              </div>
-              
-              {/* Action buttons grouped */}
-              <div className="flex items-center gap-1 md:gap-2">
-                {/* File operations group */}
-                <div className="flex items-center gap-0.5 md:gap-1 bg-gray-100 rounded-lg p-1">
-                  <button 
-                    onClick={onPickFile} 
-                    className="px-2 md:px-2.5 py-1.5 rounded-md text-sm font-medium text-gray-700 hover:bg-white hover:shadow-sm transition-all inline-flex items-center gap-1.5"
-                    aria-label="Import markdown file"
-                    title="Import .md file"
-                  >
-                    <Upload className="h-4 w-4" aria-hidden="true" />
-                    <span className="hidden md:inline">Import</span>
-                  </button>
-                  <button 
-                    onClick={exportMarkdown} 
-                    className="px-2 md:px-2.5 py-1.5 rounded-md text-sm font-medium text-gray-700 hover:bg-white hover:shadow-sm transition-all inline-flex items-center gap-1.5"
-                    aria-label="Export as markdown file"
-                    title="Export as .md file"
-                  >
-                    <FileText className="h-4 w-4" aria-hidden="true" />
-                    <span className="hidden md:inline">Export MD</span>
-                  </button>
-                  <button 
-                    onClick={exportHtml} 
-                    className="px-2 md:px-2.5 py-1.5 rounded-md text-sm font-medium text-gray-700 hover:bg-white hover:shadow-sm transition-all inline-flex items-center gap-1.5"
-                    aria-label="Export as HTML file"
-                    title="Export as .html file"
-                  >
-                    <FileCode className="h-4 w-4" aria-hidden="true" />
-                    <span className="hidden md:inline">Export HTML</span>
-                  </button>
-                </div>
-
-                {/* Theme selector moved to Live Preview header (desktop) */}
-
-                {/* Additional actions */}
-                <div className="hidden md:flex items-center gap-1">
-                  <Link 
-                    href="/guide"
-                    className="px-2 lg:px-2.5 py-1.5 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-100 transition-colors inline-flex items-center gap-1.5"
-                    title="Markdown guide and tips"
-                  >
-                    <BookOpen className="h-4 w-4" aria-hidden="true" />
-                    <span className="hidden lg:inline">Guide</span>
-                  </Link>
-                  <a 
-                    href="https://github.com/celery94/md-view"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="px-2 lg:px-2.5 py-1.5 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-100 transition-colors inline-flex items-center gap-1.5"
-                    aria-label="GitHub repository"
-                    title="Open GitHub repository"
-                  >
-                    <Github className="h-4 w-4" aria-hidden="true" />
-                    <span className="hidden lg:inline">GitHub</span>
-                  </a>
-                  <button 
-                    onClick={resetSample} 
-                    className="px-2 lg:px-2.5 py-1.5 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-100 transition-colors inline-flex items-center gap-1.5"
-                    aria-label="Reset to sample content"
-                    title="Reset to sample markdown"
-                  >
-                    <RotateCw className="h-4 w-4" aria-hidden="true" />
-                    <span className="hidden lg:inline">Reset</span>
-                  </button>
-                </div>
-
-                {/* Mobile actions menu */}
-                <div className="md:hidden">
-                  <QuickActionsMenu
-                    onImport={onPickFile}
-                    onExportMarkdown={exportMarkdown}
-                    onExportHtml={exportHtml}
-                    onReset={resetSample}
-                    onGuide={() => window.open('/guide', '_blank')}
-                    onGithub={() => window.open('https://github.com/celery94/md-view', '_blank', 'noopener,noreferrer')}
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-slate-100">
+      <div
+        className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950"
+        aria-hidden="true"
+      />
+      <div
+        className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.18),_transparent_60%)]"
+        aria-hidden="true"
+      />
+      <div
+        className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_bottom,_rgba(129,140,248,0.18),_transparent_55%)]"
+        aria-hidden="true"
+      />
+      <div
+        className="pointer-events-none absolute -right-[18%] top-[12%] -z-10 h-[420px] w-[420px] rounded-full bg-sky-500/20 blur-3xl"
+        aria-hidden="true"
+      />
+      <div
+        className="pointer-events-none absolute -left-[20%] bottom-[-5%] -z-10 h-[520px] w-[520px] rounded-full bg-indigo-500/20 blur-3xl"
+        aria-hidden="true"
+      />
+      <div className="relative z-10 flex min-h-screen flex-col">
+        {/* Header */}
+        <header className="border-b border-white/10 bg-white/70 shadow-lg backdrop-blur-sm supports-[backdrop-filter]:bg-white/60">
+          <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-4 py-4 text-slate-900 sm:px-6 lg:px-8">
+            {/* Main navigation bar */}
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              {/* Left section - Logo and title */}
+              <div className="flex flex-wrap items-center gap-3 md:gap-4">
+                <Link
+                  href="/"
+                  className="flex items-center gap-2 rounded-full border border-white/70 bg-white/80 px-2 py-1.5 text-slate-900 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:bg-white focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-2 focus:ring-offset-white md:gap-3 md:px-3 md:py-2"
+                  aria-label="MD-View Home"
+                  title="MD-View Home"
+                >
+                  <img
+                    src="/md-view-icon.svg"
+                    alt="MD-View logo"
+                    className="h-7 w-7 rounded shadow-sm transition-transform duration-200 md:h-8 md:w-8"
                   />
+                  <div className="hidden sm:block">
+                    <h1 className="text-lg font-bold md:text-xl">MD-View</h1>
+                    <p className="text-xs leading-tight text-slate-500">Markdown Studio</p>
+                  </div>
+                </Link>
+
+                {/* View mode selector */}
+                <div className="hidden md:block">
+                  <ViewModeSelector currentMode={viewMode} onModeChange={setViewMode} />
+                </div>
+              </div>
+
+              {/* Right section - Actions */}
+              <div className="flex flex-wrap items-center justify-end gap-2 md:gap-3">
+                {/* Mobile view mode selector */}
+                <div className="md:hidden">
+                  <ViewModeSelector currentMode={viewMode} onModeChange={setViewMode} />
+                </div>
+
+                {/* Action buttons grouped */}
+                <div className="flex items-center gap-1.5 md:gap-2">
+                  {/* File operations group */}
+                  <div className="flex items-center gap-1 rounded-full border border-white/70 bg-white/60 p-1 shadow-sm backdrop-blur-sm">
+                    <button
+                      onClick={onPickFile}
+                      className={`${actionButtonClass} px-2.5 py-1.5 text-xs md:text-sm`}
+                      aria-label="Import markdown file"
+                      title="Import .md file"
+                    >
+                      <Upload className="h-4 w-4" aria-hidden="true" />
+                      <span className="hidden md:inline">Import</span>
+                    </button>
+                    <button
+                      onClick={exportMarkdown}
+                      className={`${actionButtonClass} px-2.5 py-1.5 text-xs md:text-sm`}
+                      aria-label="Export as markdown file"
+                      title="Export as .md file"
+                    >
+                      <FileText className="h-4 w-4" aria-hidden="true" />
+                      <span className="hidden md:inline">Export MD</span>
+                    </button>
+                    <button
+                      onClick={exportHtml}
+                      className={`${actionButtonClass} px-2.5 py-1.5 text-xs md:text-sm`}
+                      aria-label="Export as HTML file"
+                      title="Export as HTML file"
+                    >
+                      <FileCode className="h-4 w-4" aria-hidden="true" />
+                      <span className="hidden md:inline">Export HTML</span>
+                    </button>
+                  </div>
+
+                  {/* Additional actions */}
+                  <div className="hidden md:flex items-center gap-1.5">
+                    <Link
+                      href="/guide"
+                      className={actionButtonClass}
+                      title="Markdown guide and tips"
+                    >
+                      <BookOpen className="h-4 w-4" aria-hidden="true" />
+                      <span className="hidden lg:inline">Guide</span>
+                    </Link>
+                    <a
+                      href="https://github.com/celery94/md-view"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={actionButtonClass}
+                      aria-label="GitHub repository"
+                      title="Open GitHub repository"
+                    >
+                      <Github className="h-4 w-4" aria-hidden="true" />
+                      <span className="hidden lg:inline">GitHub</span>
+                    </a>
+                    <button
+                      onClick={resetSample}
+                      className={actionButtonClass}
+                      aria-label="Reset to sample content"
+                      title="Reset to sample markdown"
+                    >
+                      <RotateCw className="h-4 w-4" aria-hidden="true" />
+                      <span className="hidden lg:inline">Reset</span>
+                    </button>
+                  </div>
+
+                  {/* Mobile actions menu */}
+                  <div className="md:hidden">
+                    <QuickActionsMenu
+                      onImport={onPickFile}
+                      onExportMarkdown={exportMarkdown}
+                      onExportHtml={exportHtml}
+                      onReset={resetSample}
+                      onGuide={() => window.open('/guide', '_blank')}
+                      onGithub={() => window.open('https://github.com/celery94/md-view', '_blank', 'noopener,noreferrer')}
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
+              <div className="space-y-3">
+                <p className="text-sm text-slate-600">
+                  Craft beautiful documentation with a distraction-free editor, instant preview, and export-ready output.
+                </p>
+                <div className="flex flex-wrap gap-2 text-xs font-medium text-slate-600">
+                  <span className="inline-flex items-center gap-1.5 rounded-full border border-sky-200/70 bg-sky-50/70 px-3 py-1 text-sky-700 shadow-sm">
+                    <Sparkles className="h-3.5 w-3.5" aria-hidden="true" />
+                    Live preview
+                  </span>
+                  <span className="inline-flex items-center gap-1.5 rounded-full border border-indigo-200/70 bg-indigo-50/70 px-3 py-1 text-indigo-700 shadow-sm">
+                    <FileCode className="h-3.5 w-3.5" aria-hidden="true" />
+                    Syntax highlighting
+                  </span>
+                  <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-200/70 bg-emerald-50/70 px-3 py-1 text-emerald-700 shadow-sm">
+                    <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
+                    Local autosave
+                  </span>
+                </div>
+              </div>
+
+              <div className="grid w-full gap-2 sm:grid-cols-3 lg:w-auto">
+                <div className="flex flex-col gap-1 rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-3 text-slate-900 shadow-sm">
+                  <span className="text-xs font-medium uppercase tracking-wide text-slate-500">Words</span>
+                  <span className="text-xl font-semibold">{wordCount.toLocaleString()}</span>
+                </div>
+                <div className="flex flex-col gap-1 rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-3 text-slate-900 shadow-sm">
+                  <span className="text-xs font-medium uppercase tracking-wide text-slate-500">Lines</span>
+                  <span className="text-xl font-semibold">{lineCount.toLocaleString()}</span>
+                </div>
+                <div className="flex flex-col gap-1 rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-3 text-slate-900 shadow-sm">
+                  <span className="text-xs font-medium uppercase tracking-wide text-slate-500">Estimated size</span>
+                  <span className="text-xl font-semibold">{formattedFileSize}</span>
                 </div>
               </div>
             </div>
           </div>
 
-          {/* Secondary bar for mobile description and stats */}
-          <div className="border-t border-gray-100 py-1.5 md:py-2">
-            <div className="sm:hidden">
-              <p className="text-xs text-gray-500 text-center">
-                Real-time markdown editor with live preview
-              </p>
-            </div>
-            <div className="hidden sm:block xl:hidden">
-              <div className="flex justify-center items-center gap-2 md:gap-3 text-xs text-gray-500">
-                <span>{markdown.split(/\s+/).filter(word => word.length > 0).length} words</span>
-                <span>•</span>
-                <span>{markdown.split('\n').length} lines</span>
-                <span>•</span>
-                <span>{Math.round(new Blob([markdown]).size / 1024)}KB</span>
-              </div>
-            </div>
-          </div>
-        </div>
+          {/* Hidden file input */}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".md,.markdown,text/markdown,text/plain"
+            className="hidden"
+            onChange={(e) => onFileChosen(e.target.files?.[0] ?? null)}
+            aria-label="File input for markdown files"
+          />
+        </header>
 
-        {/* Hidden file input */}
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept=".md,.markdown,text/markdown,text/plain"
-          className="hidden"
-          onChange={(e) => onFileChosen(e.target.files?.[0] ?? null)}
-          aria-label="File input for markdown files"
-        />
-      </header>
-
-      {/* Main content */}
-      <main ref={containerRef} className="flex-1 flex flex-col md:flex-row overflow-hidden" role="main">
+        {/* Main content */}
+        <main className="flex-1 px-3 pb-6 pt-4 sm:px-6 lg:px-8" role="main">
+          <div
+            ref={containerRef}
+            className="mx-auto flex h-full w-full max-w-6xl flex-col gap-4 md:flex-row md:gap-6"
+          >
         {/* Editor panel */}
         {(viewMode === 'editor' || viewMode === 'split') && (
           <section
             className={`
-              w-full p-4 flex flex-col
-              ${viewMode === 'split' ? 'md:h-auto border-b md:border-b-0 md:border-r border-gray-200' : 'h-full'}
+              relative flex w-full flex-col rounded-3xl border border-white/20 bg-white/80 p-5 text-slate-900 shadow-xl shadow-slate-900/10 backdrop-blur transition-all duration-300
+              ${viewMode === 'split' ? 'md:h-auto' : 'h-full'}
             `}
-            style={viewMode === 'split' ? { width: "100%", flexBasis: `${ratio * 100}%` } : undefined}
+            style={viewMode === 'split' ? { flexBasis: `${ratio * 100}%` } : undefined}
             onDrop={onDrop}
             onDragOver={onDragOver}
             aria-label="Markdown editor section"
           >
-            <div className="mb-3 flex-shrink-0">
-              <h2 className="text-lg font-semibold text-gray-700">Markdown Editor</h2>
-              <p className="text-xs text-gray-500">Type your markdown here or drop a .md file to load it</p>
+            <div className="mb-4 flex items-center justify-between">
+              <div>
+                <h2 className="text-base font-semibold text-slate-900 md:text-lg">Markdown Editor</h2>
+                <p className="text-xs text-slate-500 md:text-sm">Type your markdown here or drop a .md file to load it</p>
+              </div>
+              <span className="hidden rounded-full bg-sky-100 px-3 py-1 text-xs font-medium text-sky-600 md:inline-flex">
+                Autosaves locally
+              </span>
             </div>
-            <div className="flex-1 min-h-0 h-64 md:h-auto">
-              <RichMarkdownEditor 
+            <div className="flex-1 min-h-0">
+              <RichMarkdownEditor
                 ref={editorRef}
-                value={markdown} 
+                value={markdown}
                 onChange={setMarkdown}
                 onScroll={handleEditorScroll}
                 scrollToPercentage={editorScrollPercentage}
@@ -555,32 +611,33 @@ export default function Home() {
         {viewMode === 'split' && (
           <div
             onMouseDown={startDrag}
-            className="hidden md:block w-1 bg-gray-200 hover:bg-blue-400 cursor-col-resize"
+            className="group hidden md:flex w-10 flex-shrink-0 cursor-col-resize items-center justify-center"
             style={{ userSelect: "none" }}
             aria-label="Resize editor and preview panels"
             role="separator"
             aria-orientation="vertical"
             tabIndex={0}
             title="Drag to resize panels"
-          />
+          >
+            <span className="h-20 w-1.5 rounded-full bg-slate-200 transition-colors duration-200 group-hover:bg-sky-400" />
+          </div>
         )}
 
         {/* Preview panel */}
         {(viewMode === 'preview' || viewMode === 'split') && (
-          <section 
+          <section
             className={`
-              w-full p-4 flex flex-col
+              relative flex w-full flex-col rounded-3xl border border-white/20 bg-white/80 p-5 text-slate-900 shadow-xl shadow-slate-900/10 backdrop-blur transition-all duration-300
               ${viewMode === 'split' ? '' : 'h-full'}
             `}
-            style={viewMode === 'split' ? { width: "100%", flexBasis: `${(1 - ratio) * 100}%` } : undefined} 
+            style={viewMode === 'split' ? { flexBasis: `${(1 - ratio) * 100}%` } : undefined}
             aria-label="Markdown preview section"
           >
-            <div className="mb-3 flex-shrink-0 flex items-center justify-between">
+            <div className="mb-4 flex items-center justify-between">
               <div>
-                <h2 className="text-lg font-semibold text-gray-700">Live Preview</h2>
-                <p className="text-xs text-gray-500">Real-time rendered markdown with syntax highlighting</p>
+                <h2 className="text-base font-semibold text-slate-900 md:text-lg">Live Preview</h2>
+                <p className="text-xs text-slate-500 md:text-sm">Real-time rendered markdown with syntax highlighting</p>
               </div>
-              {/* Theme selector on the right side of Live Preview header */}
               <div className="flex items-center gap-2">
                 <div className="hidden lg:block">
                   <CompactThemeSelector currentTheme={currentTheme} onThemeChange={setCurrentTheme} />
@@ -591,9 +648,9 @@ export default function Home() {
               </div>
             </div>
             <div className="flex-1 min-h-0 h-64 md:h-auto">
-              <MarkdownPreview 
-                ref={previewRef} 
-                content={debouncedMarkdown} 
+              <MarkdownPreview
+                ref={previewRef}
+                content={debouncedMarkdown}
                 theme={currentTheme}
                 onScroll={handlePreviewScroll}
                 scrollToPercentage={previewScrollPercentage}
@@ -601,8 +658,10 @@ export default function Home() {
             </div>
           </section>
         )}
-      </main>
-    </div>
+      </div>
+    </main>
+  </div>
+  </div>
   );
 }
 

--- a/components/CompactThemeSelector.tsx
+++ b/components/CompactThemeSelector.tsx
@@ -13,11 +13,11 @@ export default function CompactThemeSelector({ currentTheme, onThemeChange }: Co
   const currentThemeObj = themes.find(t => t.name === currentTheme) || themes[0];
 
   return (
-    <div className="relative group">
+    <div className="relative">
       <select
         value={currentTheme}
         onChange={(e) => onThemeChange(e.target.value)}
-        className="appearance-none pl-8 pr-6 py-1.5 text-sm bg-white border border-gray-200 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer min-w-[100px]"
+        className="min-w-[110px] appearance-none rounded-lg border border-white/70 bg-white/70 pl-8 pr-6 py-1.5 text-sm text-slate-700 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:bg-white focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-2 focus:ring-offset-white cursor-pointer"
         aria-label="Select preview theme"
         title={`Current theme: ${currentThemeObj.displayName}`}
       >
@@ -27,12 +27,12 @@ export default function CompactThemeSelector({ currentTheme, onThemeChange }: Co
           </option>
         ))}
       </select>
-      <Palette 
-        className="absolute left-2 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" 
-        aria-hidden="true" 
+      <Palette
+        className="pointer-events-none absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 transform text-sky-500"
+        aria-hidden="true"
       />
-      <div className="absolute right-1.5 top-1/2 transform -translate-y-1/2 pointer-events-none">
-        <svg className="h-3 w-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <div className="pointer-events-none absolute right-1.5 top-1/2 -translate-y-1/2 transform">
+        <svg className="h-3 w-3 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
         </svg>
       </div>

--- a/components/MarkdownEditor.tsx
+++ b/components/MarkdownEditor.tsx
@@ -65,7 +65,7 @@ const MarkdownEditor = forwardRef<HTMLTextAreaElement, MarkdownEditorProps>(
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder="Start typing your markdown here..."
-        className="w-full h-full p-4 border border-gray-200 rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white text-black font-mono text-sm leading-relaxed overflow-auto"
+        className="flex-1 w-full h-full resize-none rounded-2xl border border-white/70 bg-white/90 p-4 font-mono text-sm leading-relaxed text-slate-900 shadow-inner focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-2 focus:ring-offset-white overflow-auto"
         spellCheck={false}
         aria-label="Markdown editor textarea"
         aria-describedby="editor-description"

--- a/components/QuickActionsMenu.tsx
+++ b/components/QuickActionsMenu.tsx
@@ -43,7 +43,7 @@ export default function QuickActionsMenu({
     <div className="relative" ref={menuRef}>
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="p-2 rounded-md text-gray-700 bg-gray-100 hover:bg-gray-200 transition-colors"
+        className="rounded-full border border-white/70 bg-white/70 p-2 text-slate-700 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:bg-white focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-2 focus:ring-offset-white"
         aria-label="More actions"
         title="More actions"
       >
@@ -51,46 +51,46 @@ export default function QuickActionsMenu({
       </button>
 
       {isOpen && (
-        <div className="absolute right-0 top-full mt-2 w-56 bg-white rounded-lg shadow-lg border border-gray-200 py-2 z-50">
+        <div className="absolute right-0 top-full mt-3 w-60 rounded-2xl border border-white/70 bg-white/80 p-2 shadow-2xl backdrop-blur-sm z-50">
           <button
             onClick={() => handleAction(onImport)}
-            className="w-full px-4 py-2.5 text-left text-sm font-medium text-gray-800 hover:bg-gray-100 flex items-center gap-3"
+            className="flex w-full items-center gap-3 rounded-xl px-4 py-2.5 text-left text-sm font-medium text-slate-700 transition-all duration-150 hover:bg-white hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-2 focus:ring-offset-white"
           >
             <Upload className="h-4 w-4" />
             Import .md file
           </button>
           <button
             onClick={() => handleAction(onExportMarkdown)}
-            className="w-full px-4 py-2.5 text-left text-sm font-medium text-gray-800 hover:bg-gray-100 flex items-center gap-3"
+            className="flex w-full items-center gap-3 rounded-xl px-4 py-2.5 text-left text-sm font-medium text-slate-700 transition-all duration-150 hover:bg-white hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-2 focus:ring-offset-white"
           >
             <FileText className="h-4 w-4" />
             Export as Markdown
           </button>
           <button
             onClick={() => handleAction(onExportHtml)}
-            className="w-full px-4 py-2.5 text-left text-sm font-medium text-gray-800 hover:bg-gray-100 flex items-center gap-3"
+            className="flex w-full items-center gap-3 rounded-xl px-4 py-2.5 text-left text-sm font-medium text-slate-700 transition-all duration-150 hover:bg-white hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-2 focus:ring-offset-white"
           >
             <FileCode className="h-4 w-4" />
             Export as HTML
           </button>
-          <hr className="my-1 border-gray-200" />
+          <hr className="my-2 border-white/60" />
           <button
             onClick={() => handleAction(onGuide)}
-            className="w-full px-4 py-2.5 text-left text-sm font-medium text-gray-800 hover:bg-gray-100 flex items-center gap-3"
+            className="flex w-full items-center gap-3 rounded-xl px-4 py-2.5 text-left text-sm font-medium text-slate-700 transition-all duration-150 hover:bg-white hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-2 focus:ring-offset-white"
           >
             <BookOpen className="h-4 w-4" />
             Markdown Guide
           </button>
           <button
             onClick={() => handleAction(onGithub)}
-            className="w-full px-4 py-2.5 text-left text-sm font-medium text-gray-800 hover:bg-gray-100 flex items-center gap-3"
+            className="flex w-full items-center gap-3 rounded-xl px-4 py-2.5 text-left text-sm font-medium text-slate-700 transition-all duration-150 hover:bg-white hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-2 focus:ring-offset-white"
           >
             <Github className="h-4 w-4" />
             View on GitHub
           </button>
           <button
             onClick={() => handleAction(onReset)}
-            className="w-full px-4 py-2.5 text-left text-sm font-medium text-gray-800 hover:bg-gray-100 flex items-center gap-3"
+            className="flex w-full items-center gap-3 rounded-xl px-4 py-2.5 text-left text-sm font-medium text-slate-700 transition-all duration-150 hover:bg-white hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-2 focus:ring-offset-white"
           >
             <RotateCw className="h-4 w-4" />
             Reset to Sample

--- a/components/RichMarkdownEditor.tsx
+++ b/components/RichMarkdownEditor.tsx
@@ -163,7 +163,7 @@ const RichMarkdownEditor = forwardRef<HTMLTextAreaElement, RichMarkdownEditorPro
   };
 
   return (
-    <div className="w-full h-full flex flex-col">
+    <div className="flex h-full w-full flex-col gap-3">
       <Toolbar
         onBold={() => applyStyle('bold')}
         onItalic={() => applyStyle('italic')}

--- a/components/ThemeSelector.tsx
+++ b/components/ThemeSelector.tsx
@@ -15,7 +15,7 @@ export default function ThemeSelector({ currentTheme, onThemeChange }: ThemeSele
       <select
         value={currentTheme}
         onChange={(e) => onThemeChange(e.target.value)}
-        className="appearance-none px-3 py-1.5 pl-8 pr-8 border rounded-md text-sm bg-white border-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer"
+        className="appearance-none rounded-lg border border-white/70 bg-white/70 px-3 py-1.5 pl-8 pr-8 text-sm text-slate-700 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:bg-white focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-2 focus:ring-offset-white cursor-pointer"
         aria-label="Select preview theme"
         title="Choose preview theme"
       >
@@ -25,12 +25,12 @@ export default function ThemeSelector({ currentTheme, onThemeChange }: ThemeSele
           </option>
         ))}
       </select>
-      <Palette 
-        className="absolute left-2 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" 
-        aria-hidden="true" 
+      <Palette
+        className="pointer-events-none absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 transform text-sky-500"
+        aria-hidden="true"
       />
       <div className="absolute right-2 top-1/2 transform -translate-y-1/2 pointer-events-none">
-        <svg className="h-4 w-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg className="h-4 w-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
         </svg>
       </div>

--- a/components/Toolbar.tsx
+++ b/components/Toolbar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Bold, Italic, Strikethrough, Heading1, Heading2, Heading3, List, ListOrdered, Link, Code, Quote, Table, Image, Undo, Redo } from 'lucide-react';
+import { Bold, Italic, Strikethrough, Heading1, Heading2, Heading3, List, ListOrdered, Link, Code, Quote, Table, Image as ImageIcon, Undo, Redo } from 'lucide-react';
 
 interface ToolbarProps {
   onBold: () => void;
@@ -21,68 +21,71 @@ interface ToolbarProps {
 }
 
 export default function Toolbar({ onBold, onItalic, onStrikethrough, onH1, onH2, onH3, onList, onOrderedList, onLink, onCode, onQuote, onTable, onImage, onUndo, onRedo }: ToolbarProps) {
+  const buttonClass =
+    "rounded-xl p-2 text-slate-600 transition-colors duration-150 hover:bg-white hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-2 focus:ring-offset-white";
+
   return (
-    <div className="flex items-center gap-2 p-2 bg-gray-100 rounded-t-lg border-b border-gray-200">
+    <div className="flex flex-wrap items-center gap-2 rounded-2xl border border-white/70 bg-white/70 p-2 shadow-sm backdrop-blur">
       {/* Undo/Redo Group */}
-      <button onClick={onUndo} className="p-2 rounded-md hover:bg-gray-200 transition-colors" title="Undo">
+      <button onClick={onUndo} className={buttonClass} title="Undo">
         <Undo className="h-4 w-4" />
       </button>
-      <button onClick={onRedo} className="p-2 rounded-md hover:bg-gray-200 transition-colors" title="Redo">
+      <button onClick={onRedo} className={buttonClass} title="Redo">
         <Redo className="h-4 w-4" />
       </button>
-      
-      <div className="w-px h-6 bg-gray-300 mx-1"></div>
-      
+
+      <div className="mx-1 h-6 w-px bg-white/70"></div>
+
       {/* Text Formatting Group */}
-      <button onClick={onBold} className="p-2 rounded-md hover:bg-gray-200 transition-colors" title="Bold">
+      <button onClick={onBold} className={buttonClass} title="Bold">
         <Bold className="h-4 w-4" />
       </button>
-      <button onClick={onItalic} className="p-2 rounded-md hover:bg-gray-200 transition-colors" title="Italic">
+      <button onClick={onItalic} className={buttonClass} title="Italic">
         <Italic className="h-4 w-4" />
       </button>
-      <button onClick={onStrikethrough} className="p-2 rounded-md hover:bg-gray-200 transition-colors" title="Strikethrough">
+      <button onClick={onStrikethrough} className={buttonClass} title="Strikethrough">
         <Strikethrough className="h-4 w-4" />
       </button>
-      <button onClick={onCode} className="p-2 rounded-md hover:bg-gray-200 transition-colors" title="Inline Code">
+      <button onClick={onCode} className={buttonClass} title="Inline Code">
         <Code className="h-4 w-4" />
       </button>
-      
-      <div className="w-px h-6 bg-gray-300 mx-1"></div>
-      
+
+      <div className="mx-1 h-6 w-px bg-white/70"></div>
+
       {/* Headings Group */}
-      <button onClick={onH1} className="p-2 rounded-md hover:bg-gray-200 transition-colors" title="Heading 1">
+      <button onClick={onH1} className={buttonClass} title="Heading 1">
         <Heading1 className="h-4 w-4" />
       </button>
-      <button onClick={onH2} className="p-2 rounded-md hover:bg-gray-200 transition-colors" title="Heading 2">
+      <button onClick={onH2} className={buttonClass} title="Heading 2">
         <Heading2 className="h-4 w-4" />
       </button>
-      <button onClick={onH3} className="p-2 rounded-md hover:bg-gray-200 transition-colors" title="Heading 3">
+      <button onClick={onH3} className={buttonClass} title="Heading 3">
         <Heading3 className="h-4 w-4" />
       </button>
-      
-      <div className="w-px h-6 bg-gray-300 mx-1"></div>
-      
+
+      <div className="mx-1 h-6 w-px bg-white/70"></div>
+
       {/* Lists and Structure Group */}
-      <button onClick={onList} className="p-2 rounded-md hover:bg-gray-200 transition-colors" title="Bulleted List">
+      <button onClick={onList} className={buttonClass} title="Bulleted List">
         <List className="h-4 w-4" />
       </button>
-      <button onClick={onOrderedList} className="p-2 rounded-md hover:bg-gray-200 transition-colors" title="Numbered List">
+      <button onClick={onOrderedList} className={buttonClass} title="Numbered List">
         <ListOrdered className="h-4 w-4" />
       </button>
-      <button onClick={onQuote} className="p-2 rounded-md hover:bg-gray-200 transition-colors" title="Blockquote">
+      <button onClick={onQuote} className={buttonClass} title="Blockquote">
         <Quote className="h-4 w-4" />
       </button>
-      
-      <div className="w-px h-6 bg-gray-300 mx-1"></div>
-      
+
+      <div className="mx-1 h-6 w-px bg-white/70"></div>
+
       {/* Media and Links Group */}
-      <button onClick={onLink} className="p-2 rounded-md hover:bg-gray-200 transition-colors" title="Link">
+      <button onClick={onLink} className={buttonClass} title="Link">
         <Link className="h-4 w-4" />
       </button>
-      <button onClick={onImage} className="p-2 rounded-md hover:bg-gray-200 transition-colors" title="Image">
-        <Image className="h-4 w-4" />
+      <button onClick={onImage} className={buttonClass} title="Image">
+        <ImageIcon className="h-4 w-4" />
       </button>
-      <button onClick={onTable} className="p-2 rounded-md hover:bg-gray-200 transition-colors" title="Table">
+      <button onClick={onTable} className={buttonClass} title="Table">
         <Table className="h-4 w-4" />
       </button>
     </div>

--- a/components/ViewModeSelector.tsx
+++ b/components/ViewModeSelector.tsx
@@ -50,7 +50,11 @@ export default function ViewModeSelector({ currentMode, onModeChange }: ViewMode
   });
 
   return (
-    <div className="flex items-center gap-0.5 md:gap-1 bg-gray-100 rounded-lg p-0.5 md:p-1" role="group" aria-label="View mode selector">
+    <div
+      className="flex items-center gap-1 rounded-full border border-white/70 bg-white/60 p-1 shadow-sm backdrop-blur"
+      role="group"
+      aria-label="View mode selector"
+    >
       {modes.map((mode) => {
         const Icon = mode.icon;
         return (
@@ -58,10 +62,10 @@ export default function ViewModeSelector({ currentMode, onModeChange }: ViewMode
             key={mode.id}
             onClick={() => onModeChange(mode.id)}
             className={`
-              px-2 md:px-3 py-1 md:py-1.5 text-xs rounded-md transition-all duration-200 inline-flex items-center gap-1 md:gap-1.5 relative
-              ${currentMode === mode.id 
-                ? 'bg-white text-gray-900 shadow-sm border border-gray-200' 
-                : 'text-gray-600 hover:text-gray-900 hover:bg-gray-50'
+              inline-flex items-center gap-1 md:gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-all duration-200
+              ${currentMode === mode.id
+                ? 'bg-gradient-to-r from-sky-500 to-indigo-500 text-white shadow'
+                : 'text-slate-600 hover:text-slate-900 hover:bg-white'
               }
               ${mode.id === 'split' ? 'view-mode-split' : ''}
             `}
@@ -70,7 +74,7 @@ export default function ViewModeSelector({ currentMode, onModeChange }: ViewMode
           >
             <Icon className="h-3.5 w-3.5" aria-hidden="true" />
             <span className="hidden sm:inline">{mode.label}</span>
-            <kbd className="hidden lg:inline-block ml-1 px-1 py-0.5 text-[10px] bg-gray-100 border border-gray-200 rounded text-gray-500">
+            <kbd className="hidden lg:inline-block ml-1 rounded-full border border-white/70 bg-white/70 px-1.5 py-0.5 text-[10px] text-slate-500">
               ⌘{mode.shortcut}
             </kbd>
           </button>


### PR DESCRIPTION
## Summary
- restyled the main layout with a gradient backdrop, glassmorphism header, and new stat cards
- refreshed editor, preview, and mobile menus with rounded cards, animated buttons, and updated theme selectors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c941b7320c8322be40289bd966cef0