### PR TITLE
feat: refine mobile header styling

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -565,8 +565,8 @@ export default function Home() {
                 </div>
               </div>
             </div>
-            <div className="flex flex-wrap items-center justify-between gap-2 pt-1 md:hidden">
-              <div className="flex flex-wrap items-center gap-2">
+            <div className="md:hidden">
+              <div className="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-slate-200/80 bg-white/80 px-2.5 py-2 shadow-sm backdrop-blur">
                 <QuickActionsMenu
                   onImport={onPickFile}
                   onExportMarkdown={exportMarkdown}

--- a/lib/ui-classes.ts
+++ b/lib/ui-classes.ts
@@ -3,11 +3,12 @@ export const ui = {
     root: 'relative min-h-screen flex flex-col overflow-hidden bg-gradient-to-b from-slate-50 via-white to-slate-50/80 text-slate-900',
 
     header:
-      'sticky top-0 z-30 border-b border-slate-200/60 bg-white/80 backdrop-blur-xl shadow-[0_1px_3px_rgb(15_23_42/0.04)] transition-all duration-300',
+      'sticky top-0 z-30 border-b border-slate-200/60 bg-gradient-to-b from-white/95 via-white/90 to-slate-50/80 backdrop-blur-xl shadow-[0_1px_3px_rgb(15_23_42/0.04)] transition-all duration-300',
 
-    headerInner: 'flex w-full flex-col gap-3 px-4 py-2.5 sm:px-6 lg:px-8',
+    headerInner: 'flex w-full flex-col gap-2.5 px-4 pb-3 pt-3 sm:gap-3 sm:px-6 sm:py-3 lg:px-8',
 
-    navRow: 'flex flex-col gap-3 md:flex-row md:items-center md:justify-between md:gap-4',
+    navRow:
+      'flex flex-col gap-2 md:flex-row md:items-center md:justify-between md:gap-4',
 
     brandLink:
       'group flex items-center gap-2.5 rounded-xl border border-transparent px-2 py-1.5 transition-all duration-200 hover:bg-gradient-to-r hover:from-slate-50 hover:to-slate-100/80 hover:border-slate-200/60 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/40 focus-visible:ring-offset-2',


### PR DESCRIPTION
### Motivation
- Improve the header appearance and spacing on small screens so the top navigation reads clearer and feels less cramped on mobile devices.

### Description
- Tweak header styles in `lib/ui-classes.ts` to use a softer top-to-bottom gradient and reduce vertical spacing via updated `headerInner` and `navRow` classes.
- Wrap mobile quick actions in `app/page.tsx` with a rounded, blurred container that adds border, padding, and shadow to better group actions on narrow viewports.

### Testing
- Started the dev server with `npm run dev` and Next.js reported the app was ready and reachable on the local dev URL.
- Ran an automated Playwright script that opened the app at a mobile viewport (`390x844`) and captured a screenshot saved to `artifacts/mobile-header.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69731c4fe6188322b732d6769a4d0dc5)